### PR TITLE
small corrections

### DIFF
--- a/Packer/openstack/data/placeholder.txt
+++ b/Packer/openstack/data/placeholder.txt
@@ -1,0 +1,1 @@
+this is a dummy file

--- a/Packer/openstack/template.json
+++ b/Packer/openstack/template.json
@@ -8,7 +8,7 @@
             "use_floating_ip": "true",
             "floating_ip_pool": "nova",
             "type": "openstack",
-            "security_groups": "ssh",
+            "security_groups": "ssh"
         }
     ],
     "provisioners": [


### PR DESCRIPTION
- I left a trailing comma in template.json - fixed
- add "data" directory as referenced in the provisioner
